### PR TITLE
Enabled the dynamic construction of the WebSocket connection URL.

### DIFF
--- a/telemetry/web/script/UrlUtils.js
+++ b/telemetry/web/script/UrlUtils.js
@@ -1,0 +1,31 @@
+/** 
+ * Utility to create the connection URL based on the current page's location.
+ * This assumes the page is being served by the Kaazing web gateway.
+ * @param service the service to connect to (e.g. "jms")
+ * @param protocol a string designating the protocol such as "http", "ws", etc. (optional, defaults to http or https based on window.location)
+ * @return a web sockets URL: &lt;protocol&gt;://&lt;server&gt;:&lt;port&gt;/&lt;service&gt;
+ */
+function makeURL(service, protocol) {
+    if (location.hash.substr(0,10) === "#ws.scheme") {
+        protocol = location.hash.substr(11,location.hash.length);
+    }
+	if (location.hash === "#cleartext") {
+	    protocol = "ws";
+	}
+	protocol = protocol || location.authority;
+	// detect explicit host:port authority
+	var authority = location.host;
+	// if (location.search) {
+		// authority = location.search.slice(1) + '.' + authority;
+	// } else {
+		// var hostPort = authority.split(':');
+		// var ports = {
+			// http : '80',
+			// https : '443'
+		// };
+		// console.log(location.protocol);
+		// authority = hostPort[0] + ':'
+				// + ports[location.protocol.substr(0, location.protocol.length - 1)];
+	// }
+	return protocol + '://' + authority + '/' + service;
+}

--- a/telemetry/web/telemetry.html
+++ b/telemetry/web/telemetry.html
@@ -38,6 +38,10 @@
 <script src="script/svg/Switch.js" type="text/javascript"></script>
 <script src="script/svg/Tilt.js" type="text/javascript"></script>
 
+<!-- URL utils -->
+<script src="script/UrlUtils.js" type="text/javascript"></script>
+
+
 <!-- Application -->
 <script type="text/javascript">
 // User interface constants
@@ -51,7 +55,9 @@ var PITCH_TILT_REVERSE = true;
 // Data constants
 var TOPIC_COMMAND = "/topic/telemetry/command";
 var TOPIC_DATA = "/topic/telemetry/data";
-var WEBSOCKET_URL = "ws://localhost:8001/jms";
+//var WEBSOCKET_URL = "ws://localhost:8001/jms";
+var WEBSOCKET_URL = makeURL("jms", "ws");
+
 
 // Global user interface
 var airspeed = null;


### PR DESCRIPTION
The UrlUtils.js contains a simple utility that takes the URL of the
page the WebSocket connection is established from, and constructs the
URL. The hard coded end-point URL now uses the makeUrl (service,
protocol) signature.
